### PR TITLE
[Feat] GlobalStyle 설정

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,9 @@
+import { GlobalStyle } from "./style/GlobalStyle";
+
 function App() {
   return (
     <div>
-      hello world
+      <GlobalStyle />
     </div>
   );
 }

--- a/src/style/GlobalStyle.jsx
+++ b/src/style/GlobalStyle.jsx
@@ -1,0 +1,37 @@
+import { createGlobalStyle } from "styled-components";
+import reset from "styled-reset";
+
+export const GlobalStyle = createGlobalStyle`
+    ${reset};
+
+    :root {
+      font-size: 62.5%;
+    }
+    * {
+      box-sizing: border-box;
+    }
+    a {
+      text-decoration: none;
+      color: inherit;
+      cursor: pointer;
+    }
+    a:visited {
+      text-decoration: none;
+      color: inherit;
+    }
+    img {
+      width: 100%;
+      vertical-align: top;
+    }
+    button {
+      border: none;
+      padding: 0;
+      background-color: inherit;
+      color: inherit;
+      font: inherit;
+      cursor: pointer;
+    }
+    input {
+      font: inherit;
+    }
+`;

--- a/src/style/GlobalStyle.jsx
+++ b/src/style/GlobalStyle.jsx
@@ -1,4 +1,4 @@
-import { createGlobalStyle } from "styled-components";
+import { createGlobalStyle, css } from "styled-components";
 import reset from "styled-reset";
 
 export const GlobalStyle = createGlobalStyle`
@@ -34,4 +34,36 @@ export const GlobalStyle = createGlobalStyle`
     input {
       font: inherit;
     }
+`;
+
+export const PageWrap = css`
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const ConWrap = css`
+  width: 1280px;
+  flex-grow: 1;
+`;
+
+export const LayoutWrap = css`
+  margin: 0 auto;
+`;
+
+export const IR = css`
+  position: absolute;
+  clip-path: inset(50%);
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+`;
+
+export const Ellipsis = css`
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;

--- a/src/style/GlobalStyle.jsx
+++ b/src/style/GlobalStyle.jsx
@@ -1,4 +1,4 @@
-import { createGlobalStyle, css } from "styled-components";
+import { createGlobalStyle } from "styled-components";
 import reset from "styled-reset";
 
 export const GlobalStyle = createGlobalStyle`
@@ -34,36 +34,4 @@ export const GlobalStyle = createGlobalStyle`
     input {
       font: inherit;
     }
-`;
-
-export const PageWrap = css`
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-`;
-
-export const ConWrap = css`
-  width: 1280px;
-  flex-grow: 1;
-`;
-
-export const LayoutWrap = css`
-  margin: 0 auto;
-`;
-
-export const IR = css`
-  position: absolute;
-  clip-path: inset(50%);
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-`;
-
-export const Ellipsis = css`
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 `;

--- a/src/style/LayoutStyle.jsx
+++ b/src/style/LayoutStyle.jsx
@@ -1,0 +1,33 @@
+import { styled, css } from "styled-components";
+
+export const PageWrap = styled.div`
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const ConWrap = styled.div`
+  width: 1280px;
+  flex-grow: 1;
+`;
+
+export const LayoutWrap = styled.div`
+  margin: 0 auto;
+`;
+
+export const IR = css`
+  position: absolute;
+  clip-path: inset(50%);
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+`;
+
+export const Ellipsis = css`
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;


### PR DESCRIPTION
### 1. 작업 내용 설명
- GlobalStyle을 설정한 브랜치입니다.

### 2. 기록사항
- 초기화 작업은 GlobalStyle.jsx에서, 공통으로 계속해서 사용될 레이아웃과 관련된 작업은 LayoutStyle.jsx로 작성해주었습니다.
- LayoutStyle.jsx의 Wrap들은 레이아웃의 역할만 하도록 `styled`로 작성하여 export했습니다.
- 폰트 설정이 추가로 필요합니다.

### 3. 기대 결과 및 구현 화면
- 전역으로 기본 스타일을 세팅하고, 공통으로 사용될 CSS를 필요에 따라 import해올 수 있습니다.

### Issue close
- #1 